### PR TITLE
Keep index when generating meta

### DIFF
--- a/src/nested_dask/backends.py
+++ b/src/nested_dask/backends.py
@@ -23,7 +23,9 @@ def make_meta_frame(x, index=None) -> npd.NestedFrame:
     """Create an empty NestedFrame to use as Dask's underlying object meta."""
 
     dtypes = x.dtypes.to_dict()
-    result = npd.NestedFrame({key: pd.Series(dtype=d) for key, d in dtypes.items()})
+    index = index if index is not None else x.index
+    index = index[:0].copy()
+    result = npd.NestedFrame({key: pd.Series(dtype=d) for key, d in dtypes.items()}, index=index)
     return result
 
 

--- a/src/nested_dask/backends.py
+++ b/src/nested_dask/backends.py
@@ -33,6 +33,8 @@ def make_meta_frame(x, index=None) -> npd.NestedFrame:
 def _nonempty_nestedframe(x, index=None) -> npd.NestedFrame:
     """Construct a new NestedFrame with the same underlying data."""
     df = meta_nonempty_dataframe(x)
+    if index is not None:
+        df.index = index
     return npd.NestedFrame(df)
 
 

--- a/src/nested_dask/core.py
+++ b/src/nested_dask/core.py
@@ -98,7 +98,7 @@ class NestedFrame(
         return NestedFrame.from_dask_dataframe(result)
 
     @classmethod
-    def from_dask_dataframe(cls, df) -> NestedFrame:
+    def from_dask_dataframe(cls, df: dd.DataFrame) -> NestedFrame:
         """Converts a Dask Dataframe to a Dask-Nested NestedFrame
 
         Parameters
@@ -110,7 +110,7 @@ class NestedFrame(
         -------
         `nested_dask.NestedFrame`
         """
-        return df.map_partitions(npd.NestedFrame)
+        return df.map_partitions(npd.NestedFrame, meta=npd.NestedFrame(df._meta.copy()))
 
     def compute(self, **kwargs):
         """Compute this Dask collection, returning the underlying dataframe or series."""

--- a/tests/nested_dask/test_nestedframe.py
+++ b/tests/nested_dask/test_nestedframe.py
@@ -1,5 +1,5 @@
-import nested_dask as nd
 import dask.dataframe as dd
+import nested_dask as nd
 import numpy as np
 import pandas as pd
 import pytest
@@ -14,13 +14,13 @@ def test_nestedframe_construction(test_dataset):
 
 
 def test_nestedframe_from_dask_keeps_index_name():
+    """test index name is set in from_dask_dataframe"""
     index_name = "test"
     a = pd.DataFrame({"a": [1, 2, 3]})
     a.index.name = index_name
     ddf = dd.from_pandas(a)
     assert ddf.index.name == index_name
     ndf = nd.NestedFrame.from_dask_dataframe(ddf)
-    aa= ndf._meta
     assert isinstance(ndf, nd.NestedFrame)
     assert ndf.index.name == index_name
 

--- a/tests/nested_dask/test_nestedframe.py
+++ b/tests/nested_dask/test_nestedframe.py
@@ -1,4 +1,5 @@
 import nested_dask as nd
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import pytest
@@ -10,6 +11,18 @@ def test_nestedframe_construction(test_dataset):
     assert len(test_dataset) == 50
     assert test_dataset.columns.to_list() == ["a", "b", "nested"]
     assert isinstance(test_dataset["nested"].dtype, NestedDtype)
+
+
+def test_nestedframe_from_dask_keeps_index_name():
+    index_name = "test"
+    a = pd.DataFrame({"a": [1, 2, 3]})
+    a.index.name = index_name
+    ddf = dd.from_pandas(a)
+    assert ddf.index.name == index_name
+    ndf = nd.NestedFrame.from_dask_dataframe(ddf)
+    aa= ndf._meta
+    assert isinstance(ndf, nd.NestedFrame)
+    assert ndf.index.name == index_name
 
 
 def test_all_columns(test_dataset):


### PR DESCRIPTION
Changes the meta generation to keep the index of the data frame, or use the one in the parameter if provided.

Fixes #36 