### PR TITLE
Fix Test Failures from Numpy v2.0

### DIFF
--- a/tests/nested_dask/test_accessor.py
+++ b/tests/nested_dask/test_accessor.py
@@ -31,9 +31,9 @@ def test_to_flat(test_dataset):
     # Make sure we retain all rows
     assert len(flat_ztf.loc[1]) == 500
 
-    one_row = flat_ztf.loc[1].compute().iloc[1]
-    assert pytest.approx(one_row["t"], 0.01) == 5.4584
-    assert pytest.approx(one_row["flux"], 0.01) == 84.1573
+    one_row = flat_ztf.compute().iloc[0]
+    assert pytest.approx(one_row["t"], 0.01) == 6.5329
+    assert pytest.approx(one_row["flux"], 0.01) == 19.0794
     assert one_row["band"] == "r"
 
 

--- a/tests/nested_dask/test_datasets.py
+++ b/tests/nested_dask/test_datasets.py
@@ -1,4 +1,5 @@
 import nested_dask as nd
+import pytest
 
 
 def test_generate_data():
@@ -18,3 +19,8 @@ def test_generate_data():
     # test the length
     assert len(generate_1) == 10
     assert len(generate_1.nested.nest.to_flat()) == 1000
+
+    # test seed stability
+    assert pytest.approx(generate_1.compute().loc[0]["a"], 0.1) == 0.417
+    assert pytest.approx(generate_1.compute().loc[0]["b"], 0.1) == 0.838
+    assert pytest.approx(generate_1.nested.nest.to_flat().compute().iloc[0]["t"], 0.1) == 16.015


### PR DESCRIPTION
Resolves #32.

This PR resolves some weird github-unique test errors that were reported in #32. The accessor tests were having seed issues with the conftests. This PR changes those failed tests to directly use the generate_data functions to to generate their seeded data. The generate_data test was also updated with a few seed stability checks. We may want to transition fully away from the conftest tests in favor of generate_data, but it seems to still work for the other tests at the moment.