### PR TITLE
Unpin from a specific nested-pandas version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    'nested-pandas==0.2.1',
+    'nested-pandas>=0.2.1',
     'numpy',
     'dask>=2024.3.0',
     'dask[distributed]>=2024.3.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    'nested-pandas>=0.2.1',
+    'nested-pandas>=0.2.1,<0.3',
     'numpy',
     'dask>=2024.3.0',
     'dask[distributed]>=2024.3.0',


### PR DESCRIPTION
We currently have nested-dask pinned to a particular version of nested-pandas, however this is annoying for simple bug fix/patch releases made to nested-pandas. I propose we change the current dependency on nested-pandas to allow new versions, but keep the current pin as a floor.
