### PR TITLE
Better Ensure `reduce` returns a NestedFrame

### DIFF
--- a/src/nested_dask/core.py
+++ b/src/nested_dask/core.py
@@ -442,6 +442,11 @@ Refer to the docstring for guidance on dtype requirements and assignment."""
                 nest_cols.append(column)
         return nest_cols
 
+    # def map_partitions(self, *args, **kwargs) -> NestedFrame:
+    #    """docstring"""
+    #    res = super().map_partitions(*args, **kwargs)
+    #    return res#.map_partitions(npd.NestedFrame, meta=npd.NestedFrame(res._meta.copy()))
+
     def _is_known_hierarchical_column(self, colname) -> bool:
         """Determine whether a string is a known hierarchical column name"""
         if "." in colname:
@@ -654,6 +659,14 @@ Refer to the docstring for guidance on dtype requirements and assignment."""
         >>>    return {"sum_col1": sum(col1), "sum_col2": sum(col2)}
 
         """
+
+        # Handle meta shorthands to produce nestedframe output
+        # route standard dict meta to nestedframe
+        if isinstance(meta, dict):
+            meta = npd.NestedFrame(meta, index=[])
+        # reroute series meta to nestedframe, per consistency with nested-pandas
+        elif isinstance(meta, tuple) and len(meta) == 2:  # len 2 to only try on proper series meta
+            meta = npd.NestedFrame(pd.Series(name=meta[0], dtype=meta[1]).to_frame())
 
         # apply nested_pandas reduce via map_partitions
         # wrap the partition in a npd.NestedFrame call for:

--- a/src/nested_dask/core.py
+++ b/src/nested_dask/core.py
@@ -663,7 +663,8 @@ Refer to the docstring for guidance on dtype requirements and assignment."""
         # Handle meta shorthands to produce nestedframe output
         # route standard dict meta to nestedframe
         if isinstance(meta, dict):
-            meta = npd.NestedFrame(meta, index=[])
+            series_dict = {item[0]: pd.Series(dtype=item[1]) for item in meta.items()}
+            meta = npd.NestedFrame(series_dict)
         # reroute series meta to nestedframe, per consistency with nested-pandas
         elif isinstance(meta, tuple) and len(meta) == 2:  # len 2 to only try on proper series meta
             meta = npd.NestedFrame(pd.Series(name=meta[0], dtype=meta[1]).to_frame())

--- a/src/nested_dask/core.py
+++ b/src/nested_dask/core.py
@@ -442,11 +442,6 @@ Refer to the docstring for guidance on dtype requirements and assignment."""
                 nest_cols.append(column)
         return nest_cols
 
-    # def map_partitions(self, *args, **kwargs) -> NestedFrame:
-    #    """docstring"""
-    #    res = super().map_partitions(*args, **kwargs)
-    #    return res#.map_partitions(npd.NestedFrame, meta=npd.NestedFrame(res._meta.copy()))
-
     def _is_known_hierarchical_column(self, colname) -> bool:
         """Determine whether a string is a known hierarchical column name"""
         if "." in colname:

--- a/tests/nested_dask/test_nestedframe.py
+++ b/tests/nested_dask/test_nestedframe.py
@@ -327,14 +327,14 @@ def test_reduce_output_type(meta):
 
     if meta == "df":
 
-        def mean_arr(b, arr): # type: ignore
-            return {"b": b, "mean": np.mean(arr)} # type: ignore
+        def mean_arr(b, arr):  # type: ignore
+            return {"b": b, "mean": np.mean(arr)}  # type: ignore
 
         reduced = nddf.reduce(mean_arr, "b", "test.a", meta={"b": int, "mean": float})
     elif meta == "series":
 
-        def mean_arr(arr): # type: ignore
-            return np.mean(arr) # type: ignore
+        def mean_arr(arr):  # type: ignore
+            return np.mean(arr)  # type: ignore
 
         reduced = nddf.reduce(mean_arr, "test.a", meta=("mean", "float"))
     assert isinstance(reduced, nd.NestedFrame)

--- a/tests/nested_dask/test_nestedframe.py
+++ b/tests/nested_dask/test_nestedframe.py
@@ -336,8 +336,9 @@ def test_reduce_output_type(meta):
         def mean_arr(arr):  # type: ignore
             return np.mean(arr)  # type: ignore
 
-        reduced = nddf.reduce(mean_arr, "test.a", meta=("mean", "float"))
+        reduced = nddf.reduce(mean_arr, "test.a", meta=(0, "float"))
     assert isinstance(reduced, nd.NestedFrame)
+    assert isinstance(reduced.compute(), npd.NestedFrame)
 
 
 def test_to_parquet_combined(test_dataset, tmp_path):

--- a/tests/nested_dask/test_nestedframe.py
+++ b/tests/nested_dask/test_nestedframe.py
@@ -327,14 +327,14 @@ def test_reduce_output_type(meta):
 
     if meta == "df":
 
-        def mean_arr(b, arr):
-            return {"b": b, "mean": np.mean(arr)}
+        def mean_arr(b, arr): # type: ignore
+            return {"b": b, "mean": np.mean(arr)} # type: ignore
 
         reduced = nddf.reduce(mean_arr, "b", "test.a", meta={"b": int, "mean": float})
     elif meta == "series":
 
-        def mean_arr(arr):
-            return np.mean(arr)
+        def mean_arr(arr): # type: ignore
+            return np.mean(arr) # type: ignore
 
         reduced = nddf.reduce(mean_arr, "test.a", meta=("mean", "float"))
     assert isinstance(reduced, nd.NestedFrame)


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
Resolves #54 
- [x] My PR includes a link to the issue that I am addressing



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->
The issue seems to be that when meta is passed using dask's shorthand notation of dicts and tuples, the result is interpreted as a dask result. All this PR does is get in front of Dask whenever these shorthands are used, and casts them to npd.NestedFrames (even in the case of a series result as is consistent with Nested-Pandas)

I originally intended to wrap map_partitions (so ignore branch name), but believe this is unnecessary as meta handling works as expected for npd.NestedFrame meta


## Code Quality
- [ ] I have read the Contribution Guide
- [ ] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [ ] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

<!-- ### Version Change Checklist [For Future Use] -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
