### PR TITLE
Switch from_flat 'index' keyword to 'on'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    'nested-pandas>=0.3.0,<0.4.0',
+    'nested-pandas>=0.3.1,<0.4.0',
     'numpy',
     'dask>=2024.3.0',
     'dask[distributed]>=2024.3.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.9"
 dependencies = [
-    'nested-pandas>=0.2.1,<0.3',
+    'nested-pandas>=0.3.0,<0.4.0',
     'numpy',
     'dask>=2024.3.0',
     'dask[distributed]>=2024.3.0',

--- a/src/nested_dask/core.py
+++ b/src/nested_dask/core.py
@@ -287,7 +287,7 @@ class NestedFrame(
         return NestedFrame.from_dask_dataframe(nf)
 
     @classmethod
-    def from_flat(cls, df, base_columns, nested_columns=None, index=None, name="nested"):
+    def from_flat(cls, df, base_columns, nested_columns=None, on=None, name="nested"):
         """Creates a NestedFrame with base and nested columns from a flat
         dataframe.
 
@@ -303,7 +303,7 @@ class NestedFrame(
             in the list will attempt to be packed into a single nested column
             with the name provided in `nested_name`. If None, is defined as all
             columns not in `base_columns`.
-        index: str, or None
+        on: str or None
             The name of a column to use as the new index. Typically, the index
             should have a unique value per row for base columns, and should
             repeat for nested columns. For example, a dataframe with two
@@ -323,7 +323,7 @@ class NestedFrame(
         meta = npd.NestedFrame(df[base_columns]._meta)
 
         if nested_columns is None:
-            nested_columns = [col for col in df.columns if (col not in base_columns) and col != index]
+            nested_columns = [col for col in df.columns if (col not in base_columns) and col != on]
 
         if len(nested_columns) > 0:
             nested_meta = pack(df[nested_columns]._meta, name)
@@ -331,7 +331,7 @@ class NestedFrame(
 
         return df.map_partitions(
             lambda x: npd.NestedFrame.from_flat(
-                df=x, base_columns=base_columns, nested_columns=nested_columns, index=index, name=name
+                df=x, base_columns=base_columns, nested_columns=nested_columns, on=on, name=name
             ),
             meta=meta,
         )

--- a/tests/nested_dask/conftest.py
+++ b/tests/nested_dask/conftest.py
@@ -1,6 +1,8 @@
 import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
+import pandas as pd
+import pyarrow as pa
 import pytest
 
 
@@ -18,7 +20,11 @@ def test_dataset():
     layer_data = {
         "t": randomstate.random(layer_size * n_base) * 20,
         "flux": randomstate.random(layer_size * n_base) * 100,
-        "band": randomstate.choice(["r", "g"], size=layer_size * n_base),
+        # Ensure pyarrow[string] dtype, not large_string
+        # https://github.com/lincc-frameworks/nested-dask/issues/71
+        "band": pd.Series(
+            randomstate.choice(["r", "g"], size=layer_size * n_base), dtype=pd.ArrowDtype(pa.string())
+        ),
         "index": np.arange(layer_size * n_base) % n_base,
     }
     layer_nf = npd.NestedFrame(data=layer_data).set_index("index").sort_index()

--- a/tests/nested_dask/test_nestedframe.py
+++ b/tests/nested_dask/test_nestedframe.py
@@ -1,14 +1,13 @@
 import dask
 import dask.dataframe as dd
+import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from nested_pandas.series.dtype import NestedDtype
-
-import nested_dask as nd
 from nested_dask.datasets import generate_data
+from nested_pandas.series.dtype import NestedDtype
 
 dask.config.set({"dataframe.convert-string": False})
 

--- a/tests/nested_dask/test_nestedframe.py
+++ b/tests/nested_dask/test_nestedframe.py
@@ -1,13 +1,14 @@
 import dask
 import dask.dataframe as dd
-import nested_dask as nd
 import nested_pandas as npd
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from nested_dask.datasets import generate_data
 from nested_pandas.series.dtype import NestedDtype
+
+import nested_dask as nd
+from nested_dask.datasets import generate_data
 
 dask.config.set({"dataframe.convert-string": False})
 
@@ -173,7 +174,7 @@ def test_from_flat():
     assert len(ndf_comp) == 2
 
     # Check using an index
-    ndf = nd.NestedFrame.from_flat(nf, base_columns=["b"], index="a")
+    ndf = nd.NestedFrame.from_flat(nf, base_columns=["b"], on="a")
     assert list(ndf.columns) == ["b", "nested"]
     assert list(ndf["nested"].nest.fields) == ["c", "d"]
     ndf_comp = ndf.compute()


### PR DESCRIPTION
Switches the `from_flat` arguments to reflect the new API introduced in nested-pandas 3.0. We pin however to 3.1 to take advantage of the fix introduced in https://github.com/lincc-frameworks/nested-pandas/pull/173

We also have a testing hot fix for a serialization error with a note to more fully address in https://github.com/lincc-frameworks/nested-dask/issues/71 