### PR TITLE
Handle `dask/dask-expr` merge with `dask/dask`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ requires-python = ">=3.9"
 dependencies = [
     'nested-pandas>=0.3.1,<0.4.0',
     'numpy',
-    'dask>=2024.3.0',
-    'dask[distributed]>=2024.3.0',
+    'dask>=2025.1.0',
+    'dask[distributed]>=2025.1.0',
     'pyarrow',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     'numpy',
     'dask>=2024.3.0',
     'dask[distributed]>=2024.3.0',
-    'dask_expr',
     'pyarrow',
 ]
 

--- a/src/nested_dask/backends.py
+++ b/src/nested_dask/backends.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 import nested_pandas as npd
 import pandas as pd
 from dask.dataframe.backends import meta_nonempty_dataframe
+from dask.dataframe.dask_expr._dispatch import get_collection_type
 from dask.dataframe.dispatch import make_meta_dispatch
 from dask.dataframe.extensions import make_array_nonempty
 from dask.dataframe.utils import meta_nonempty
-from dask_expr import get_collection_type
 from nested_pandas.series.ext_array import NestedExtensionArray
 
 from .core import NestedFrame

--- a/src/nested_dask/core.py
+++ b/src/nested_dask/core.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import os
 
 import dask.dataframe as dd
-import dask_expr as dx
+import dask.dataframe.dask_expr as dx
 import nested_pandas as npd
 import pandas as pd
 import pyarrow as pa
-from dask_expr._collection import new_collection
+from dask.dataframe.dask_expr._collection import new_collection
 from nested_pandas.series.dtype import NestedDtype
 from nested_pandas.series.packer import pack, pack_flat
 from pandas._libs import lib


### PR DESCRIPTION
The [smoke unit tests](https://github.com/lincc-frameworks/nested-dask/actions/runs/12881592576/job/35912393377#step:6:46) are failing because `dask/dask-expr` has been merged with the base `dask/dask` package on [v2025.1.0](https://docs.dask.org/en/stable/changelog.html#v2025-1-0). This pull request bumps the dask version and fixes the relevant imports.