### PR TITLE
Bump dask to 2025.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     'nested-pandas>=0.3.1,<0.4.0',
     'numpy',
     'dask>=2025.1.0',
-    'dask[distributed]>=2025.1.0',
+    'dask[distributed]>=2025.2.0',
     'pyarrow',
 ]
 


### PR DESCRIPTION
We actually need it after https://github.com/lincc-frameworks/nested-dask/pull/82