### PR TITLE
add wrapper for sort_values

### DIFF
--- a/src/nested_dask/core.py
+++ b/src/nested_dask/core.py
@@ -684,21 +684,21 @@ Refer to the docstring for guidance on dtype requirements and assignment."""
         """
 
         # Resolve target layer
-        target = []
+        targets = []
         if isinstance(by, str):
             by = [by]
         # Check "by" columns for hierarchical references
         for col in by:
             if self._is_known_hierarchical_column(col):
-                target.append(col.split(".")[0])
+                targets.append(col.split(".")[0])
             else:
-                target.append("base")
+                targets.append("base")
 
         # Ensure one target layer, preventing multi-layer operations
-        target = np.unique(target).tolist()
-        if len(target) > 1:
+        unq_targets = np.unique(targets).tolist()
+        if len(unq_targets) > 1:
             raise ValueError("Queries cannot target multiple structs/layers, write a separate query for each")
-        target_layer = target[0]
+        target_layer = unq_targets[0]
 
         # Just use dask's sort_values if the target is the base layer
         # Drops divisions, but this is expected behavior of a sorting operation

--- a/src/nested_dask/core.py
+++ b/src/nested_dask/core.py
@@ -698,7 +698,7 @@ Refer to the docstring for guidance on dtype requirements and assignment."""
         target = np.unique(target).tolist()
         if len(target) > 1:
             raise ValueError("Queries cannot target multiple structs/layers, write a separate query for each")
-        target_layer = str(target[0])
+        target_layer = target[0]
 
         # Just use dask's sort_values if the target is the base layer
         # Drops divisions, but this is expected behavior of a sorting operation

--- a/src/nested_dask/core.py
+++ b/src/nested_dask/core.py
@@ -647,8 +647,10 @@ Refer to the docstring for guidance on dtype requirements and assignment."""
             The ideal number of output partitions. If None, use the same as the
             input. If ‘auto’ then decide by memory use. Not used when sorting
             nested layers.
-        ascending: bool, optional
-            Sort ascending vs. descending. Defaults to True.
+        ascending: bool or list[bool], optional
+            Sort ascending vs. descending. Defaults to True. Specify list for
+            multiple sort orders. If this is a list of bools, must match the
+            length of the by.
         na_position: {‘last’, ‘first’}, optional
             Puts NaNs at the beginning if ‘first’, puts NaN at the end if
             ‘last’. Defaults to ‘last’.

--- a/tests/nested_dask/test_nestedframe.py
+++ b/tests/nested_dask/test_nestedframe.py
@@ -299,6 +299,26 @@ def test_dropna(test_dataset_with_nans):
     assert len(flat_nested_nan_free) == len(flat_nested) - 1
 
 
+def test_sort_values(test_dataset):
+    """test the sort_values function"""
+
+    # test sorting on base columns
+    sorted_base = test_dataset.sort_values(by="a")
+    assert sorted_base["a"].values.compute().tolist() == sorted(test_dataset["a"].values.compute().tolist())
+
+    # test sorting on nested columns
+    sorted_nested = test_dataset.sort_values(by="nested.flux", ascending=False)
+    assert sorted_nested.compute().loc[0]["nested"]["flux"].values.tolist() == sorted(
+        test_dataset.loc[0]["nested.flux"].values.compute().tolist(),
+        reverse=True,
+    )
+    assert sorted_nested.known_divisions  # Divisions should be known
+
+    # Make sure we trigger multi-target exception
+    with pytest.raises(ValueError):
+        test_dataset.sort_values(by=["a", "nested.flux"])
+
+
 def test_reduce(test_dataset):
     """test the reduce function"""
 

--- a/tests/nested_dask/test_nestedframe.py
+++ b/tests/nested_dask/test_nestedframe.py
@@ -308,8 +308,8 @@ def test_sort_values(test_dataset):
 
     # test sorting on nested columns
     sorted_nested = test_dataset.sort_values(by="nested.flux", ascending=False)
-    assert sorted_nested.compute().loc[0]["nested"]["flux"].values.tolist() == sorted(
-        test_dataset.loc[0]["nested.flux"].values.compute().tolist(),
+    assert sorted_nested.compute().iloc[0]["nested"]["flux"].values.tolist() == sorted(
+        test_dataset.compute().iloc[0]["nested"]["flux"].values.tolist(),
         reverse=True,
     )
     assert sorted_nested.known_divisions  # Divisions should be known


### PR DESCRIPTION
Resolves #86

Adds a wrapper for sort_values. This one is a bit different than the usual wrapper as dask has more of it's own functionality because sorting is a much more dask-sensitive operation. This is kind of a crude solution, but we effectively just call dasks sort_values when not sorting on nested layers, but then call a map_partitioned version of nested-pandas sort_values when working on nested layers. 


These really act as two different functions under the same namespace, as top-level sorting invokes the neccesary parallelization and consequences of a shuffle that you'd expect with dask, dropping divisions. But sorting on nested layers is a contained problem that avoids dask shuffles and preserves the divisions information. We could break these out, but I think it would be better to make the functionality "feel" like nested-pandas so that would instead motivate breaking the functions out at the nested-pandas level too. The main issue I have with keeping them as one is that the kwarg set is subtly switching from one API to the other, and so things like optional kwargs may be confusing if a user switches their sorting from base->nested or vice-versa.

^**But realistically, it may be fine to keep these as a single modified function until we get feedback that it's confusing in real use cases?**
