### PR TITLE
update nested-pandas pin to >=0.3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    'nested-pandas>=0.3.1,<0.4.0',
+    'nested-pandas>=0.3.8,<0.4.0',
     'numpy',
     'dask>=2025.1.0',
     'dask[distributed]>=2025.2.0',


### PR DESCRIPTION
Latest Nested-Dask should use Nested-Pandas v0.3.8+ to ensure latest functionality of sort_values and reduce on the Nested-Pandas side is being used in those calls on the Nested-Dask side.
