### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 [![Read The Docs](https://img.shields.io/readthedocs/nested-dask)](https://nested-dask.readthedocs.io/)
 [![Benchmarks](https://img.shields.io/github/actions/workflow/status/lincc-frameworks/nested-dask/asv-main.yml?label=benchmarks)](https://lincc-frameworks.github.io/nested-dask/)
 
+__ARCHIVE NOTICE: This repository is no longer being maintained. The original purpose of this package was to enable dask with the extended nested-pandas API, with the specific aim of using this to support the [LSDB](https://github.com/astronomy-commons/lsdb) project. In April 2025, the contents of this package were [migrated directly into LSDB](https://github.com/astronomy-commons/lsdb/pull/713) to allow for tailored behavior to LSDB's specific operational needs. As a result, any needed changes to dask-compatibility for nested-pandas are happening directly within LSDB and not in this repository. Further, maintaining a generalized dask layer for nested-pandas is not directly within the critical path for LINCC-Frameworks effort at this time. If you found your way here and wished there was a maintained package that provided a dask-layer for nested-pandas for something you are working on, please feel free to voice that as an issue filed to [nested-pandas](https://github.com/lincc-frameworks/nested-pandas/issues).__
+
 A [dask](https://www.dask.org/) extension of 
 [nested-pandas](https://nested-pandas.readthedocs.io/en/latest/).
 


### PR DESCRIPTION
Added an archive notice indicating that the repository is no longer maintained and details about its migration to LSDB.